### PR TITLE
Support non ascii messages

### DIFF
--- a/src/main/java/io/evanwong/oss/hipchat/v2/commons/PostRequest.java
+++ b/src/main/java/io/evanwong/oss/hipchat/v2/commons/PostRequest.java
@@ -1,5 +1,6 @@
 package io.evanwong.oss.hipchat.v2.commons;
 
+import org.apache.http.Consts;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -30,7 +31,7 @@ public abstract class PostRequest<T> extends Request<T> {
         HttpPost httpPost = new HttpPost(BASE_URL + encodedPath);
         httpPost.addHeader(new BasicHeader("Authorization", "Bearer " + accessToken));
         httpPost.addHeader(new BasicHeader("Content-Type", "application/json"));
-        httpPost.setEntity(new StringEntity(objectWriter.writeValueAsString(params)));
+        httpPost.setEntity(new StringEntity(objectWriter.writeValueAsString(params), Consts.UTF_8));
         return httpClient.execute(httpPost, HttpClientContext.create());
     }
 }

--- a/src/main/java/io/evanwong/oss/hipchat/v2/commons/PutRequest.java
+++ b/src/main/java/io/evanwong/oss/hipchat/v2/commons/PutRequest.java
@@ -1,5 +1,6 @@
 package io.evanwong.oss.hipchat.v2.commons;
 
+import org.apache.http.Consts;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPut;
@@ -30,7 +31,7 @@ public abstract class PutRequest<T> extends Request<T> {
         HttpPut httpPut = new HttpPut(BASE_URL + encodedPath);
         httpPut.addHeader(new BasicHeader("Authorization", "Bearer " + accessToken));
         httpPut.addHeader(new BasicHeader("Content-Type", "application/json"));
-        httpPut.setEntity(new StringEntity(objectWriter.writeValueAsString(params)));
+        httpPut.setEntity(new StringEntity(objectWriter.writeValueAsString(params), Consts.UTF_8));
         return httpClient.execute(httpPut, HttpClientContext.create());
     }
 }


### PR DESCRIPTION
Non ascii text becomes ? because StringEntity default charaset is ISO-8859-1. Set UTF-8 to support non ascii text message.